### PR TITLE
Fix board index boundary check

### DIFF
--- a/platform/gol-board.js
+++ b/platform/gol-board.js
@@ -150,7 +150,7 @@ function GolBoard() {
 				v = (i == 0) ?
 					that.getIndex(pixels[i][j][0], that.rows / 2 + pixels[i][j][1]) :
 					that.getIndex(pixels[i][j][0], that.rows / 2 - 1 - pixels[i][j][1]);
-				if (v < 0 || v > that.points) {
+                                if (v < 0 || v >= that.points) {
 					_err('new pixel out of range');
 				} else {
 					pixelIndices[i][j] = v;


### PR DESCRIPTION
## Summary
- fix out of range check in `GolBoard.getNewPixelIndices`

## Testing
- `node -e "require('./platform/gol-board.js')"`


------
https://chatgpt.com/codex/tasks/task_e_687b8c17e9e08321b9bb45dacb7d0aef